### PR TITLE
docs(graph-fleet): remove outdated proto stub generation references

### DIFF
--- a/src/agents/rds_manifest_generator/docs/README.md
+++ b/src/agents/rds_manifest_generator/docs/README.md
@@ -53,7 +53,8 @@ The agent automatically fetches proto schema files from the `project-planton` re
 
 ```bash
 cd /Users/suresh/scm/github.com/plantoncloud-inc/graph-fleet
-make run
+make deps  # Install dependencies
+make run   # Start LangGraph Studio
 ```
 
 Then open http://localhost:8123 and select the `rds_manifest_generator` graph.


### PR DESCRIPTION
## Summary

Updated GraphFleet documentation to remove all references to proto stub generation infrastructure, which was removed on October 31, 2025. Documentation now accurately describes the runtime proto file fetching approach that GraphFleet actually uses.

## Context

GraphFleet removed all proto stub generation infrastructure (buf configs, generated stubs, related dependencies) in a cleanup documented in changelog `2025-10-31-023740-remove-unused-proto-dependencies.md`. However, the README and agent documentation still contained outdated references to `make gen-stubs`, Buf Schema Registry, and generated Python stubs, which confused the actual architecture.

GraphFleet uses runtime proto file fetching - it clones `.proto` files from the `project-planton` Git repository at startup and parses them as text using regex to extract schema information. No code generation or buf tooling is involved.

## Changes

**Main README.md:**
- Updated Quick Start section to remove "Generate proto stubs" comment from `make deps`
- Rewrote Development section to explain runtime proto fetching instead of BSR stub generation
- Updated Project Structure to remove `apis/stubs/`, buf config files, and related directories
- Removed `make gen-stubs` from Available Commands list
- Renamed "Proto Dependencies" section to "Proto Schema Understanding" and completely rewrote to explain runtime fetching, text-based parsing, and local caching

**RDS Agent README.md:**
- Added explicit `make deps` step with correct comment in Starting the Agent section

## Implementation notes

- All changes are documentation-only - no code changes required
- The Developer Guide was already correct and didn't need updates
- Changes align with the actual codebase state after the October 31 cleanup
- Documentation now clearly communicates that GraphFleet uses runtime Git cloning and text parsing, not protobuf code generation

## Breaking changes

None - documentation-only changes.

## Test plan

- Verified no linter errors in updated files
- Reviewed updated documentation for accuracy against actual codebase
- Confirmed Developer Guide already accurately described runtime proto fetching
- Cross-referenced with cleanup changelog to ensure consistency

## Risks

None - documentation updates only, no code or behavior changes.

## Checklist

- [x] Docs updated (this PR)
- [x] Tests added/updated (not applicable - docs only)
- [x] Backward compatible (docs only)
