### PR TITLE
docs(repo): organize security documentation into docs/security folder

### DIFF
--- a/docs/security/SECURITY_IMPROVEMENTS_IMPLEMENTED.md
+++ b/docs/security/SECURITY_IMPROVEMENTS_IMPLEMENTED.md
@@ -221,7 +221,7 @@ Review `.github/SECURITY.md` to understand:
 2. `.github/SECURITY.md` - Security policy and reporting
 3. `.pre-commit-config.yaml` - Pre-commit hooks configuration
 4. `SECURITY_ASSESSMENT.md` - Detailed security analysis
-5. `SECURITY_IMPROVEMENTS_IMPLEMENTED.md` - This document
+5. `docs/security/SECURITY_IMPROVEMENTS_IMPLEMENTED.md` - This document
 
 ### Modified Settings (via GitHub API)
 1. Repository security settings


### PR DESCRIPTION
## Summary

Moved security documentation from the repository root into a new `docs/security/` directory to improve organization and reduce root-level clutter.

## Context

The security documentation file `SECURITY_IMPROVEMENTS_IMPLEMENTED.md` was sitting at the repository root, which made the root directory cluttered and less organized. Creating a dedicated `docs/` folder structure improves discoverability and provides a scalable location for future documentation.

## Changes

- Created new directory structure: `docs/security/`
- Moved `SECURITY_IMPROVEMENTS_IMPLEMENTED.md` from root to `docs/security/`
- Updated self-reference in the moved file to reflect new path
- Repository root now only contains essential files like `README.md`

## Implementation notes

- The `.github/SECURITY.md` file remains in its standard GitHub location as intended
- The new `docs/` folder provides a foundation for organizing other documentation types in the future (architecture, operations, etc.)

## Breaking changes

None. This is purely a documentation reorganization with no code changes.

## Test plan

- Verified file was successfully moved to `docs/security/`
- Verified root directory is cleaner (only `README.md` remains)
- Updated internal reference to reflect new path
- Directory structure validated with `ls` commands

## Risks

None. This is a low-risk documentation move with no functional changes.

## Checklist

- [x] Docs updated (path reference updated in moved file)
- [x] Tests added/updated (not applicable)
- [x] Backward compatible (documentation move only)
