### PR TITLE
fix(rds-agent): remove internal tool references from user-facing messages

### DIFF
--- a/src/agents/rds_manifest_generator/agent.py
+++ b/src/agents/rds_manifest_generator/agent.py
@@ -228,9 +228,9 @@ Use `generate_rds_manifest()` to create the YAML:
 
 After generation, the manifest is available at `/manifest.yaml`:
 - Let the user know the manifest has been saved to `/manifest.yaml`
-- They can use the `read_file` tool to view it if they want to see the complete YAML
+- The file is visible in the file viewer and can be downloaded from the UI
 - Point out key configurations (engine, size, Multi-AZ, encryption, etc.)
-- The file is visible in the UI and persists in the conversation
+- The file persists in the conversation
 
 ### 5. Offer Next Steps
 
@@ -259,7 +259,7 @@ Here's what was configured:
 - **Network**: Deployed in your specified subnets with security groups
 
 The manifest is now available in the virtual filesystem at `/manifest.yaml`. You can:
-1. View it by using the `read_file` tool
+1. View it in the file viewer
 2. Download it from the UI
 3. Save it locally and deploy using: `planton apply -f rds-instance.yaml`
 

--- a/src/agents/rds_manifest_generator/tools/manifest_tools.py
+++ b/src/agents/rds_manifest_generator/tools/manifest_tools.py
@@ -300,7 +300,7 @@ def generate_rds_manifest(
         f"✓ Generated AWS RDS Instance manifest!\n"
         f"The manifest has been saved to {manifest_path}\n"
         f"Resource name: {final_name}\n"
-        f"You can view the manifest by reading {manifest_path}"
+        f"The manifest is available in the file viewer and can be downloaded from the UI"
     )
     
     # Convert to FileData - matching DeepAgents' write_file pattern


### PR DESCRIPTION
## Summary

Replaced internal implementation details ("read_file tool") in RDS Manifest Agent user-facing messages with user-friendly language that describes actual UI features (file viewer, download from UI).

## Context

Users were seeing confusing technical references to "read_file tool" in agent responses when their manifests were generated. This internal terminology was unhelpful since users interact with a web interface and don't have access to or knowledge of internal tools. The messaging needed to align with what users can actually see and do in the UI.

## Changes

- **manifest_tools.py**: Updated success message to say "The manifest is available in the file viewer and can be downloaded from the UI" instead of "You can view the manifest by reading {manifest_path}"
- **agent.py** (line 231): Updated system prompt instructions to reference "file viewer" instead of "read_file tool"
- **agent.py** (line 262): Updated example conversation flow to show "View it in the file viewer" instead of "View it by using the read_file tool"

## Implementation notes

- All changes are purely presentational (string replacements in messages)
- No functionality changes - files still saved to `/manifest.yaml`, UI components unchanged
- Updated both tool output and system prompt examples to ensure consistent messaging
- Pattern can be reused for other agents to maintain user-friendly communication

## Breaking changes

None - this is a presentation-only change with no API or functionality modifications.

## Test plan

- ✅ Verified no linter errors introduced
- ✅ Confirmed all string replacements are accurate
- ✅ Validated syntax correctness in both files
- Manual testing: Agent will now display user-friendly messages when manifests are generated

## Risks

**Low risk**: 
- Only affects displayed text, no logic changes
- Improves user experience with no downsides
- Easy to revert if needed (simple string changes)

**Rollback**: Revert commit to restore original messaging if issues arise.

## Checklist

- [x] Docs updated (if needed) - System prompt examples updated
- [x] Tests added/updated (if needed) - N/A for text changes
- [x] Backward compatible - Yes, no breaking changes

