### PR TITLE
fix(pipeline): correct kustomize-build task resolver from hub to git

### DIFF
--- a/.planton/pipeline.yaml
+++ b/.planton/pipeline.yaml
@@ -89,24 +89,24 @@ spec:
     - name: kustomize-build
       runAfter: ["build-and-push"]
       taskRef:
-        resolver: hub
+        resolver: git
         params:
-          - name: catalog
-            value: tekton-catalog-tasks
-          - name: type
-            value: artifact
-          - name: kind
-            value: task
-          - name: name
-            value: kustomize-build
-          - name: version
-            value: "0.1"
+          - name: url
+            value: "https://github.com/plantoncloud/tekton-hub.git"
+          - name: revision
+            value: "main"
+          - name: pathInRepo
+            value: "tasks/kustomize-build.yaml"
       workspaces:
         - name: source
           workspace: source
       params:
-        - name: kustomize-dir
-          value: $(params.project-root)/_kustomize/overlays/prod
         - name: config-map-name
           value: $(params.kustomize-manifests-config-map-name)
+        - name: config-map-namespace
+          value: planton-cloud-pipelines
+        - name: project-root
+          value: $(params.project-root)
+        - name: kustomize-base-directory
+          value: "_kustomize"
 


### PR DESCRIPTION
## Summary

Fixed the graph-fleet pipeline by correcting the `kustomize-build` task resolver configuration from `hub` to `git`. The pipeline was successfully queued in Temporal but failed during Tekton execution because it tried to fetch a custom task from the public Artifact Hub instead of the private Planton Cloud Tekton Hub repository.

## Context

The graph-fleet service pipeline was triggered successfully via GitHub webhooks and queued in Temporal, but consistently failed during Tekton execution with a "CouldntGetTask" error. Investigation revealed that the `kustomize-build` task was configured to use the `hub` resolver pointing to a non-existent Artifact Hub resource, when it should use the `git` resolver to fetch the custom task from `github.com/plantoncloud/tekton-hub`.

## Changes

- Updated `.planton/pipeline.yaml` to change `kustomize-build` task resolver from `hub` to `git`
- Replaced hub-specific params (`catalog`, `type`, `kind`, `name`, `version`) with git-specific params (`url`, `revision`, `pathInRepo`)
- Updated task parameters to match the custom task interface:
  - Removed: `kustomize-dir` 
  - Added: `config-map-namespace` and `kustomize-base-directory`
  - Retained: `config-map-name` and `project-root`
- Aligned configuration with working patterns used in other Planton Cloud service pipelines

## Implementation notes

- The `kustomize-build` task is a custom Planton Cloud task hosted in the private `github.com/plantoncloud/tekton-hub` repository, not available on the public Artifact Hub
- The `git` resolver fetches task definitions directly from Git repositories, enabling access to private/custom tasks
- Configuration now matches the working pattern used across all other Planton Cloud services (verified in planton-cloud/.planton/pipeline.yaml and backend/services/integration/.pipeline/pipeline.yaml)

## Breaking changes

None. This is a bug fix that restores intended functionality without changing any APIs or contracts.

## Test plan

- Commit and push this change to trigger a new pipeline run
- Verify in Temporal UI that the workflow executes successfully
- Check Tekton PipelineRun shows all three tasks complete (git-checkout, build-and-push, kustomize-build)
- Confirm Docker image is pushed to GHCR with correct tag
- Validate ConfigMap in `planton-cloud-pipelines` namespace contains generated kustomize manifests

## Risks

- **Low risk**: This is a configuration correction to match working patterns
- **Rollback**: Can revert the single file change if issues arise
- **Validation**: Pipeline failure will be immediately visible in Tekton/Temporal UI without affecting running services

## Checklist

- [x] Docs updated (comprehensive diagnostic report created: `_cursor/graph-fleet-pipeline-diagnostic-report.md`)
- [x] Tests added/updated (verification steps documented in changelog)
- [x] Backward compatible (yes, restores intended behavior)

