### PR TITLE
fix(pipeline): add package-credentials workspace for GCP Artifact Registry auth

### DIFF
--- a/.planton/pipeline.yaml
+++ b/.planton/pipeline.yaml
@@ -15,7 +15,7 @@ spec:
       default: "main"
     - name: image-name
       type: string
-      description: "The full destination image (ghcr.io/plantoncloud-inc/graph-fleet:tag)"
+      description: "The full destination image (asia-south1-docker.pkg.dev/.../graph-fleet:tag)"
     - name: kustomize-manifests-config-map-name
       type: string
       description: "Name of the config-map to store service manifests"
@@ -30,6 +30,8 @@ spec:
   workspaces:
     - name: source
       description: "Workspace where source code is cloned"
+    - name: package-credentials
+      description: "Workspace with GCP service account for Artifact Registry auth"
   
   tasks:
     # 1. Clone repository
@@ -58,7 +60,7 @@ spec:
         - name: subdirectory
           value: ""
     
-    # 2. Build and push Docker image to GHCR
+    # 2. Build and push Docker image to GCP Artifact Registry
     - name: build-and-push
       runAfter: ["git-checkout"]
       taskRef:


### PR DESCRIPTION
## Summary

Fixed Tekton pipeline failure by adding missing `package-credentials` workspace declaration to enable GCP Artifact Registry authentication. Also updated comments to accurately reflect GCP Artifact Registry usage instead of GitHub Container Registry.

## Context

The graph-fleet pipeline was failing at the Docker image push stage with credentials not found error. Investigation revealed the Pipeline definition was missing the `package-credentials` workspace declaration that all other Planton Cloud backend services include. This prevented Kaniko from accessing the GCP service account credentials needed to authenticate with GCP Artifact Registry.

Error:
```
error getting credentials using GOOGLE_APPLICATION_CREDENTIALS environment variable: 
open /workspace/source/.package-credentials/google-service-account.json: no such file or directory
```

## Changes

- **Added `package-credentials` workspace declaration** to match standard pattern used across all Planton Cloud services
- **Updated parameter descriptions** to correctly reference GCP Artifact Registry instead of GHCR
- **Updated task comment** from "Build and push Docker image to GHCR" to "Build and push Docker image to GCP Artifact Registry"

## Implementation notes

- The workspace declaration enables Tekton to mount the GCP service account secret
- Tekton's built-in credential helper (`docker-credential-gcr`) automatically discovers and uses the mounted credentials
- No changes needed to Kaniko task itself - it automatically uses credentials from Tekton's credential system
- This aligns graph-fleet with the pattern used by temporal-worker, service-hub, agent-fleet-worker, and all other backend services

## Breaking changes

None - this is a bug fix that enables the pipeline to work correctly.

## Test plan

- Verified workspace declaration matches pattern in planton-cloud-java-backend-service-pipeline
- Confirmed other services (agent-fleet-worker, temporal-worker) all use GCP Artifact Registry with same workspace pattern
- Pipeline should now complete successfully when triggered

## Risks

**Low risk** - This fix aligns with the established pattern used by all other services. The PipelineRun (generated by service-hub) already binds the `package-credentials` workspace; this change simply allows the Pipeline to declare it so credentials can be mounted.

**Rollback**: If issues occur, revert the workspace declaration (though this is unlikely as it only enables existing credentials to be used).

## Checklist

- [x] Docs updated (comments corrected to reflect GCP Artifact Registry)
- [x] Tests added/updated (not applicable - infrastructure fix)
- [x] Backward compatible (yes - bug fix only)

