### PR TITLE
fix(build): resolve Docker build error with two-phase Poetry installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,16 @@ WORKDIR /app
 # Copy dependency files
 COPY pyproject.toml poetry.lock ./
 
-# Install Poetry and dependencies
+# Install Poetry and dependencies only (skip project package)
 RUN pip install --no-cache-dir poetry==1.8.5 && \
     poetry config virtualenvs.create false && \
-    poetry install --no-dev --no-interaction --no-ansi
+    poetry install --no-dev --no-root --no-interaction --no-ansi
 
 # Copy application code
 COPY . .
+
+# Now install the project package itself
+RUN poetry install --no-dev --only-root --no-interaction --no-ansi
 
 # Create directory for state persistence
 RUN mkdir -p /app/.langgraph


### PR DESCRIPTION
## Summary

Fixed critical Docker build failure in graph-fleet service by splitting Poetry installation into two phases: first installing dependencies with `--no-root`, then installing the project package with `--only-root` after source code is copied. This resolves the `/app/src/* does not contain any element` error while preserving Docker layer caching optimization.

## Context

The Docker build was failing because Poetry attempted to install the `graph-fleet` package before the `src/` directory was copied into the container. The Dockerfile used a common optimization pattern (copy dependency files first, install dependencies, then copy code), but Poetry's default behavior of installing both dependencies and the current project in a single command caused it to fail when the source code wasn't available yet.

This issue was blocking the CI/CD pipeline and preventing deployment of the graph-fleet service to Kubernetes.

## Changes

- **Dockerfile**: Split Poetry installation into two phases
  - Added `--no-root` flag to initial `poetry install` to skip installing the project package
  - Added second `poetry install --only-root` command after `COPY . .` to install only the project package
  - This ensures dependencies are installed first, then the project package is installed after source code is available

## Implementation notes

- The `--no-root` flag tells Poetry to install only dependencies, skipping the current project
- The `--only-root` flag tells Poetry to install only the current project, skipping dependencies (which are already installed)
- This approach maintains the Docker layer caching benefit: dependency layers are cached separately from code layers
- Code changes won't trigger dependency reinstallation, improving build performance

## Breaking changes

None. This is purely a build infrastructure fix with no changes to application behavior or APIs.

## Test plan

- Verified Dockerfile syntax and structure
- The build will be tested in CI/CD pipeline after PR is merged
- Expected outcome: Docker image builds successfully and can be deployed to Kubernetes

## Risks

**Low risk**: This change only affects the Docker build process, not runtime behavior.

**Rollback**: If issues occur, can revert the Dockerfile change and investigate further. The previous working state was before the Docker build optimization was added.

## Checklist

- [x] Docs updated (if needed) - N/A, internal build fix
- [x] Tests added/updated (if needed) - N/A, build infrastructure change
- [x] Backward compatible - Yes, no runtime changes

