### PR TITLE
fix(kustomize): remove unsupported volumes configuration from MicroserviceKubernetes

### DIFF
--- a/_kustomize/base/service.yaml
+++ b/_kustomize/base/service.yaml
@@ -37,18 +37,6 @@ spec:
           servicePort: 80
           containerPort: 8080
           isIngressPort: true
-      # Persistent volume for state management
-      volumes:
-        - name: langgraph-state
-          mountPath: /app/.langgraph
-          spec:
-            persistentVolumeClaim:
-              storageClassName: standard
-              accessModes:
-                - ReadWriteOnce
-              resources:
-                requests:
-                  storage: 10Gi
   availability:
     minReplicas: 1
     horizontalPodAutoscaling:


### PR DESCRIPTION
## Summary

Fixed deployment blocker by removing unsupported `volumes` configuration from MicroserviceKubernetes YAML specification. The `volumes` field is not supported in the MicroserviceKubernetes proto schema, causing YAML validation failures.

## Context

The graph-fleet service deployment was failing with error:
```
Cannot find field: volumes in message project.planton.provider.kubernetes.workload.microservicekubernetes.v1.MicroserviceKubernetesContainerApp
```

Unlike other Kubernetes workload types (MongoDB, Neo4j, Prometheus), `MicroserviceKubernetes` does not support persistent volumes in its proto definition. A comprehensive proposal document has been created in the planton-cloud repository to add this capability at the platform level.

## Changes

- Removed unsupported `volumes` configuration (lines 40-51) from `_kustomize/base/service.yaml`
- Cleaned up comment about persistent volume for state management
- Deployment now uses ephemeral storage (state lost on pod restart)

## Implementation notes

- **Trade-off**: LangGraph state is now ephemeral and will be lost on pod restarts
- **Acceptable**: User explicitly approved this as temporary measure until volume support is added to platform
- **Clean removal**: No workarounds or hacks, proper YAML structure maintained
- **Verified**: YAML validation passes, kustomization structure intact

## Breaking changes

None. This is a pre-deployment fix (service wasn't successfully deployed yet).

## Test plan

- [x] YAML schema validation passes
- [x] No linter errors
- [x] Kustomization files verified (base, local, prod overlays)
- [ ] Deploy to verify deployment succeeds (manual verification needed)
- [ ] Monitor pod restarts to confirm ephemeral state behavior

## Risks

**Medium**: LangGraph conversation state will be lost on pod restarts until persistent volume support is added to the platform.

**Mitigation**: 
- Acceptable for initial rollout as approved by user
- Comprehensive proposal document created for adding volume support
- Migration path documented for when feature is available

**Rollback**: Re-add volumes configuration (will fail deployment, but preserves desired state in git history)

## Checklist

- [x] Docs updated (proposal document created in planton-cloud repo)
- [ ] Tests added/updated (deployment verification pending)
- [x] Backward compatible (no previous successful deployment)

