### PR TITLE
fix(build): remove invalid requirements-storage directory causing mypy error

### DIFF
--- a/src/agents/rds_manifest_generator/docs/requirements-storage/__init__.py
+++ b/src/agents/rds_manifest_generator/docs/requirements-storage/__init__.py
@@ -1,6 +1,0 @@
-"""Requirements storage documentation package.
-
-This package contains documentation about the requirements storage system
-used in the RDS manifest generator agent.
-"""
-


### PR DESCRIPTION
## Summary

Fixed mypy type checking failure by removing the leftover `requirements-storage/` directory with an invalid hyphenated name. This restores the `make build` command to working state.

## Context

The `make build` command was failing during mypy type checking with the error: `requirements-storage is not a valid Python package name`. This blocked local development validation and CI/CD pipelines.

Python package names cannot contain hyphens - only underscores, letters, and numbers are valid. During a previous refactoring (documented in changelog `2025-11-10-222211-fix-ruff-linting-errors.md`), the directory was renamed from `requirements-storage` to `requirements_storage`, but the old hyphenated directory was not fully removed.

## Changes

- Deleted `src/agents/rds_manifest_generator/docs/requirements-storage/` directory
- The valid `requirements_storage/` directory (with underscore) already contained all necessary documentation

## Implementation notes

- The removed directory only contained an `__init__.py` file identical to the one in the valid directory
- All documentation (README.md, phase docs) already existed in `requirements_storage/`
- No code logic was affected - this was purely cleanup of an invalid package name

## Breaking changes

None

## Test plan

- Verified `make build` passes successfully after deletion:
  - ✅ Ruff linting: All checks passed
  - ✅ Mypy type checking: Success, no issues found in 25 source files

## Risks

- **Risk**: Minimal - only removing a duplicate/invalid directory
- **Rollback**: Simple - recreate the directory if needed (though it should not be needed)
- **Confidence**: High - build verification confirms the fix

## Checklist

- [x] Docs updated (if needed) - not applicable, documentation unaffected
- [x] Tests added/updated (if needed) - not applicable, no test changes needed
- [x] Backward compatible - yes, no API or functionality changes

