### PR TITLE
fix(agents/aws-rds-creator): resolve D413 docstring formatting errors

### DIFF
--- a/_changelog/2025-11/2025-11-27-192043-fix-docstring-formatting-d413.md
+++ b/_changelog/2025-11/2025-11-27-192043-fix-docstring-formatting-d413.md
@@ -1,0 +1,87 @@
+# Fix Docstring Formatting D413 Linter Errors
+
+**Date**: November 27, 2025
+
+## Summary
+
+Fixed 7 ruff linter D413 errors by adding required blank lines after the last section in docstrings. This ensures consistent docstring formatting across the AWS RDS Instance Creator agent codebase and resolves build failures caused by linting violations.
+
+## Problem Statement
+
+The `make build` command was failing during the ruff linting phase with 7 D413 violations. These errors indicated missing blank lines after the last docstring sections (like "Raises:" or "Example:") before the closing triple quotes.
+
+### Pain Points
+
+- Build process failing on linting stage, blocking development workflow
+- Inconsistent docstring formatting in MCP tool wrappers and middleware
+- PEP 257 docstring convention violations preventing code quality checks from passing
+
+## Solution
+
+Added blank lines after the last section in all affected docstrings to comply with ruff's D413 rule, which enforces proper spacing in multi-section docstrings according to PEP 257 conventions.
+
+### Files Modified
+
+**`src/agents/aws_rds_instance_creator/mcp_tool_wrappers.py`** (5 fixes)
+- `list_environments_for_org` - Added blank line after "Raises:" section
+- `list_cloud_resource_kinds` - Added blank line after "Raises:" section
+- `get_cloud_resource_schema` - Added blank line after "Raises:" section
+- `create_cloud_resource` - Added blank line after "Raises:" section
+- `search_cloud_resources` - Added blank line after "Raises:" section
+
+**`src/agents/aws_rds_instance_creator/middleware/mcp_loader.py`** (2 fixes)
+- `McpToolsLoader` class docstring - Added blank line after "Example:" section
+- `before_agent` method - Added blank line after "Raises:" section
+
+## Implementation Details
+
+### Before
+
+```python
+    Raises:
+        RuntimeError: If MCP tools not loaded or tool not found
+    """
+```
+
+### After
+
+```python
+    Raises:
+        RuntimeError: If MCP tools not loaded or tool not found
+
+    """
+```
+
+The fix involves adding a single blank line between the last content line and the closing triple quotes for each affected docstring.
+
+## Benefits
+
+- ✅ Build process passes ruff linting stage
+- ✅ Consistent docstring formatting across codebase
+- ✅ Compliance with PEP 257 docstring conventions
+- ✅ Improved code quality and maintainability
+- ✅ No more linting errors blocking development workflow
+
+## Impact
+
+**Affected Components**:
+- AWS RDS Instance Creator agent MCP tool wrappers
+- MCP tools loader middleware
+
+**Developer Experience**:
+- Builds now complete successfully through linting stage
+- Developers can proceed with normal development workflow
+- Code quality standards are maintained
+
+## Related Work
+
+- Recent work on MCP authentication and tool loading (2025-11-27-184705)
+- AWS RDS Instance Creator agent development (2025-11-26-230559)
+- Dynamic MCP authentication implementation (2025-11-27-110912)
+
+---
+
+**Status**: ✅ Production Ready
+**Timeline**: ~10 minutes
+**Code Metrics**: 2 files modified, 7 docstrings fixed
+

--- a/src/agents/aws_rds_instance_creator/mcp_tool_wrappers.py
+++ b/src/agents/aws_rds_instance_creator/mcp_tool_wrappers.py
@@ -37,6 +37,7 @@ def list_environments_for_org(
         
     Raises:
         RuntimeError: If MCP tools not loaded or tool not found
+
     """
     if not hasattr(runtime.langgraph_runtime, 'mcp_tools'):
         raise RuntimeError(
@@ -73,6 +74,7 @@ def list_cloud_resource_kinds(
         
     Raises:
         RuntimeError: If MCP tools not loaded or tool not found
+
     """
     if not hasattr(runtime.langgraph_runtime, 'mcp_tools'):
         raise RuntimeError(
@@ -111,6 +113,7 @@ def get_cloud_resource_schema(
         
     Raises:
         RuntimeError: If MCP tools not loaded or tool not found
+
     """
     if not hasattr(runtime.langgraph_runtime, 'mcp_tools'):
         raise RuntimeError(
@@ -157,6 +160,7 @@ def create_cloud_resource(
         
     Raises:
         RuntimeError: If MCP tools not loaded or tool not found
+
     """
     if not hasattr(runtime.langgraph_runtime, 'mcp_tools'):
         raise RuntimeError(
@@ -207,6 +211,7 @@ def search_cloud_resources(
         
     Raises:
         RuntimeError: If MCP tools not loaded or tool not found
+
     """
     if not hasattr(runtime.langgraph_runtime, 'mcp_tools'):
         raise RuntimeError(

--- a/src/agents/aws_rds_instance_creator/middleware/mcp_loader.py
+++ b/src/agents/aws_rds_instance_creator/middleware/mcp_loader.py
@@ -40,6 +40,7 @@ class McpToolsLoader(AgentMiddleware):
             context_schema=AwsRdsCreatorState,
         )
         ```
+
     """
     
     async def before_agent(
@@ -63,6 +64,7 @@ class McpToolsLoader(AgentMiddleware):
         Raises:
             ValueError: If user token not found in config
             RuntimeError: If MCP tools cannot be loaded
+
         """
         # Check if tools already loaded for this thread (idempotency)
         if hasattr(runtime, 'mcp_tools') and runtime.mcp_tools:


### PR DESCRIPTION
## Summary

Fixed 7 ruff D413 linter errors by adding required blank lines after the last section in docstrings for the AWS RDS Instance Creator agent components. This resolves build failures and ensures compliance with PEP 257 docstring conventions.

## Context

The `make build` command was failing during the ruff linting phase with 7 D413 violations. These errors indicated missing blank lines after the last docstring sections (like "Raises:" or "Example:") before the closing triple quotes. The D413 rule enforces proper spacing in multi-section docstrings according to PEP 257 conventions.

## Changes

- **`src/agents/aws_rds_instance_creator/mcp_tool_wrappers.py`**: Added blank lines after "Raises:" sections in 5 functions:
  - `list_environments_for_org`
  - `list_cloud_resource_kinds`
  - `get_cloud_resource_schema`
  - `create_cloud_resource`
  - `search_cloud_resources`

- **`src/agents/aws_rds_instance_creator/middleware/mcp_loader.py`**: Added blank lines in 2 locations:
  - After "Example:" section in `McpToolsLoader` class docstring
  - After "Raises:" section in `before_agent` method

## Implementation notes

The fix is straightforward - adding a single blank line between the last content line and the closing triple quotes in each affected docstring. This pattern follows PEP 257 multi-section docstring formatting requirements enforced by ruff.

## Breaking changes

None. This is a formatting-only change with no functional impact.

## Test plan

- Ran `make build` successfully - ruff linting passes with "All checks passed!"
- Verified no linter errors remain in modified files using `read_lints` tool
- Confirmed all 7 D413 errors are resolved

## Risks

None. This is a low-risk formatting fix that improves code quality and resolves build failures. No logic or functionality changes.

## Checklist

- [x] Docs updated (N/A - docstring formatting only)
- [x] Tests added/updated (N/A - formatting change)
- [x] Backward compatible (yes - no functional changes)

